### PR TITLE
[신이재] 구매하기 데이터에 이미지 항목 추가

### DIFF
--- a/src/pages/ProductDetail/components/GoodsTop/GoodsForm.jsx
+++ b/src/pages/ProductDetail/components/GoodsTop/GoodsForm.jsx
@@ -74,6 +74,7 @@ const GoodsForm = ({ data }) => {
       JSON.stringify({
         prodIdx: data.id,
         options: selectedItems,
+        thumbnail: data.img[0],
         delivery_fee: 0,
       })
     );


### PR DESCRIPTION
- sessionStorage `PROD_SELECTED_OPTION_<id>` 의 값에 사진을 추가했습니다. `thumbnail`로 접근
```
 {
        prodIdx: data.id,
        options: selectedItems,
        thumbnail: data.img[0],
        delivery_fee: 0,
      }
```