### PR TITLE
[신이재] 구매하기 데이터에 아이템 이름 추가

### DIFF
--- a/src/pages/ProductDetail/components/GoodsTop/GoodsForm.jsx
+++ b/src/pages/ProductDetail/components/GoodsTop/GoodsForm.jsx
@@ -73,6 +73,7 @@ const GoodsForm = ({ data }) => {
       `PROD_SELECTED_OPTION_${data.id}`,
       JSON.stringify({
         prodIdx: data.id,
+        prodName: data.title,
         options: selectedItems,
         thumbnail: data.img[0],
         delivery_fee: 0,


### PR DESCRIPTION
- sessionStorage PROD_SELECTED_OPTION_<id> 의 값에 아이템 이름을 추가했습니다.`prodName`로 접근
```
 {
        prodIdx: data.id,
        prodName: data.title,
        options: selectedItems,
        thumbnail: data.img[0],
        delivery_fee: 0,
 }